### PR TITLE
Added more russian street abbreviations

### DIFF
--- a/plpgsql/get_localized_name.sql
+++ b/plpgsql/get_localized_name.sql
@@ -254,6 +254,10 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_ru(longname text) RETURNS TEXT 
   abbrev=regexp_replace(abbrev,'тупик','туп.');
   abbrev=regexp_replace(abbrev,'улица','ул.');
   abbrev=regexp_replace(abbrev,'бульвар','бул.');
+  abbrev=regexp_replace(abbrev,'площадь','пл.');
+  abbrev=regexp_replace(abbrev,'проспект','просп.');
+  abbrev=regexp_replace(abbrev,'спуск','сп.');
+  abbrev=regexp_replace(abbrev,'набережная','наб.');
   return abbrev;
  END;
 $$ LANGUAGE 'plpgsql' IMMUTABLE;


### PR DESCRIPTION
_Endlich habe ich Zeit, um hier vorbeizuschauen._

Diese Abkürzungen umfassen fast alle russische Straßennamen.

P. S. Kartenstil "MapSurfer.NET" (bekannt auch als "OpenMapSurfer") kürzt auch Straßennamen beim Rendering. Dort kann man auch was abgucken:
http://edward17.github.io/LayersCollection/#map=5/56.37742/46.27441&layers=1003

P. P. S. Ich kann auch solche Funktion für Ukrainisch erstellen.