### PR TITLE
Replaces 'regexp_match' with 'regexp_matches

### DIFF
--- a/plpgsql/get_localized_name_from_tags.sql
+++ b/plpgsql/get_localized_name_from_tags.sql
@@ -164,7 +164,7 @@ CREATE or REPLACE FUNCTION osml10n_gen_combined_name(local_name text,
                      strict option to disable this behaviour.
                   */
                   if (pos = 1) THEN
-                    IF regexp_match(substring(unacc,length(unacc_local)+1,1),'[\s\(\)\-,;:/\[\]]') IS NOT NULL THEN
+                    IF regexp_matches(substring(unacc,length(unacc_local)+1,1),'[\s\(\)\-,;:/\[\]]') IS NOT NULL THEN
                       raise notice 'swapping primary/second name';
                       loc_in_brackets = false;
                     END IF;


### PR DESCRIPTION
I got the following error in renderd:
```
renderd[1798]:    reason: Postgis Plugin: ERROR:  function regexp_match(text, unknown) does not exist
LINE 1: SELECT regexp_match(substring(unacc,length(unacc_local)+1,1)...
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
QUERY:  SELECT regexp_match(substring(unacc,length(unacc_local)+1,1),'[\s\(\)\-,;:/\[\]]') IS NOT NULL
CONTEXT:  PL/pgSQL function osml10n_gen_combined_name(text,text,hstore,boolean,boolean,text,boolean,boolean,boolean) line 101 at IF
```

I replaced it with regexp_matches (that is used everywhere else) and it works now.