### PR TITLE
Split osml10n_street_abbrev_all in function of the detected alphabet to overpass the limit of cached regex #40

### DIFF
--- a/plpgsql/get_localized_name_from_tags.sql
+++ b/plpgsql/get_localized_name_from_tags.sql
@@ -46,6 +46,26 @@ CREATE or REPLACE FUNCTION osml10n_contains_cjk(text) RETURNS BOOLEAN AS $$
   END;
 $$ LANGUAGE 'plpgsql' IMMUTABLE;
 
+/*
+   helper function "osml10n_contains_cyrillic"
+  checks if string contains Cyrillic characters
+  = 0x0400-0x04FF in unicode table
+*/
+CREATE or REPLACE FUNCTION osml10n_contains_cyrillic(text) RETURNS BOOLEAN AS $$
+  DECLARE
+    i integer;
+    c integer;
+  BEGIN
+    FOR i IN 1..char_length($1) LOOP
+      c = ascii(substr($1, i, 1));
+      IF ((c > x'0400'::int) AND (c < x'04FF'::int)) THEN
+        RETURN true;
+      END IF;
+    END LOOP;
+    RETURN false;
+  END;
+$$ LANGUAGE 'plpgsql' IMMUTABLE;
+
 /* 
    helper function "osml10n_gen_combined_name"
    Will create a name+local_name pair


### PR DESCRIPTION
Use less regex by using latin or not sub function.

Avoid regex cache limit.

Less regex -> beter perf.