### PR TITLE
Mark all street_abbrv.sql as PARALLEL SAFE

### DIFF
--- a/plpgsql/geo_transliterate.sql
+++ b/plpgsql/geo_transliterate.sql
@@ -63,4 +63,4 @@ CREATE or REPLACE FUNCTION osml10n_geo_translit(name text, place geometry DEFAUL
       return osml10n_translit(name);
     END IF;
   END;
-$$ LANGUAGE plpgsql STABLE;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;

--- a/plpgsql/get_country.sql
+++ b/plpgsql/get_country.sql
@@ -31,4 +31,4 @@ CREATE or REPLACE FUNCTION osml10n_get_country(feature geometry) RETURNS TEXT AS
    order by area limit 1;
    return country;
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;

--- a/plpgsql/get_country_name.sql
+++ b/plpgsql/get_country_name.sql
@@ -77,4 +77,4 @@ CREATE or REPLACE FUNCTION osml10n_get_country_name(tags hstore, separator text 
   END IF;
   return array_to_string(names,separator);
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;

--- a/plpgsql/get_localized_name_from_tags.sql
+++ b/plpgsql/get_localized_name_from_tags.sql
@@ -24,7 +24,7 @@ CREATE or REPLACE FUNCTION osml10n_is_latin(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN true;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_contains_cjk"
@@ -44,7 +44,7 @@ CREATE or REPLACE FUNCTION osml10n_contains_cjk(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /*
    helper function "osml10n_contains_cyrillic"
@@ -64,7 +64,7 @@ CREATE or REPLACE FUNCTION osml10n_contains_cyrillic(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_gen_combined_name"
@@ -264,7 +264,7 @@ CREATE or REPLACE FUNCTION osml10n_gen_combined_name(local_name text,
    END IF;
   END IF;
  END;
-$combined$ LANGUAGE 'plpgsql' IMMUTABLE;
+$combined$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 
 /*
@@ -355,7 +355,7 @@ CREATE or REPLACE FUNCTION osml10n_get_name_from_tags(tags hstore,
      return NULL;
    END IF;
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;
 
 CREATE or REPLACE FUNCTION osml10n_get_name_without_brackets_from_tags(tags hstore,
                                                                        targetlang text DEFAULT 'de',
@@ -420,7 +420,7 @@ CREATE or REPLACE FUNCTION osml10n_get_name_without_brackets_from_tags(tags hsto
      return NULL;
    END IF;
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;
 
 /*
 
@@ -442,7 +442,7 @@ CREATE or REPLACE FUNCTION osml10n_get_placename_from_tags(tags hstore,
 
    return(osml10n_get_name_from_tags(tags,loc_in_brackets,false,show_brackets,separator,targetlang,place));
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;
 
 
 CREATE or REPLACE FUNCTION osml10n_get_streetname_from_tags(tags hstore, 
@@ -459,4 +459,4 @@ CREATE or REPLACE FUNCTION osml10n_get_streetname_from_tags(tags hstore,
    END IF;
    return(osml10n_get_name_from_tags(tags,loc_in_brackets,true,show_brackets,separator,targetlang,place));
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;

--- a/plpgsql/street_abbrv.sql
+++ b/plpgsql/street_abbrv.sql
@@ -38,7 +38,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev(longname text, langcode text) R
   WHEN undefined_function THEN
    return longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_all"
@@ -53,7 +53,7 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_all(longname text) RETURNS TEXT
   ELSE
     osml10n_street_abbrev_latin(longname)
   END;
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_all_latin"
@@ -70,7 +70,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_latin(longname text) RETURNS TE
   abbrev=osml10n_street_abbrev_fr(abbrev);
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_non_latin"
@@ -86,7 +86,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_non_latin(longname text) RETURN
   abbrev=osml10n_street_abbrev_uk(abbrev);
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 
 
@@ -131,7 +131,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_de(longname text) RETURNS TEXT 
   END IF;
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_fr"
@@ -170,7 +170,7 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_fr(longname text) RETURNS TEXT 
 
   RETURN longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_es"
@@ -181,7 +181,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_es(longname text) RETURNS TEXT 
  BEGIN
   return longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_pt"
@@ -192,7 +192,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_pt(longname text) RETURNS TEXT 
  BEGIN
   return longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_en"
@@ -246,7 +246,7 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_en(longname text) RETURNS TEXT 
 
   RETURN longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 
 
@@ -268,7 +268,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_ru(longname text) RETURNS TEXT 
   abbrev=replace(abbrev,'набережная','наб.');
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 /* 
    helper function "osml10n_street_abbrev_uk"
@@ -288,4 +288,4 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_uk(longname text) RETURNS TEXT 
   abbrev=replace(abbrev,'набережна','наб.');
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;


### PR DESCRIPTION
Mark all postgres osml10n function as `PARALLEL SAFE`.

It is required to able to make queries using this function parallel.