### PR TITLE
Optimize SQL functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
         run: |
           cd src
           sudo apt-get -y install ./build/postgresql-*-osml10n_*_amd64.deb
-          pip3 install tltk
+          pip3 install tltk wheel
           ./tests/runtests_in_virtualenv.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
         run: |
           cd src
           sudo apt-get -y install ./build/postgresql-*-osml10n_*_amd64.deb
-          pip3 install tltk wheel
+          pip3 install tltk
           ./tests/runtests_in_virtualenv.sh

--- a/plpgsql/charset_helpers.sql
+++ b/plpgsql/charset_helpers.sql
@@ -24,7 +24,7 @@ CREATE or REPLACE FUNCTION osml10n_is_latin(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN true;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
 
 /*
    helper function "osml10n_contains_cjk"
@@ -44,7 +44,7 @@ CREATE or REPLACE FUNCTION osml10n_contains_cjk(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
 
 /*
    helper function "osml10n_contains_cyrillic"
@@ -64,4 +64,4 @@ CREATE or REPLACE FUNCTION osml10n_contains_cyrillic(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;

--- a/plpgsql/charset_helpers.sql
+++ b/plpgsql/charset_helpers.sql
@@ -9,7 +9,7 @@ https://github.com/giggls/openstreetmap-carto-de
 Licence AGPL http://www.gnu.org/licenses/agpl-3.0.de.html
 */
 
-/* 
+/*
    helper function "osml10n_is_latin"
    checks if string consists of latin characters only
 */
@@ -24,9 +24,9 @@ CREATE or REPLACE FUNCTION osml10n_is_latin(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN true;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
 
-/* 
+/*
    helper function "osml10n_contains_cjk"
   checks if string contains CJK characters
   = 0x4e00-0x9FFF in unicode table
@@ -44,7 +44,7 @@ CREATE or REPLACE FUNCTION osml10n_contains_cjk(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
 
 /*
    helper function "osml10n_contains_cyrillic"
@@ -64,4 +64,4 @@ CREATE or REPLACE FUNCTION osml10n_contains_cyrillic(text) RETURNS BOOLEAN AS $$
     END LOOP;
     RETURN false;
   END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;

--- a/plpgsql/get_country.sql
+++ b/plpgsql/get_country.sql
@@ -31,4 +31,4 @@ CREATE or REPLACE FUNCTION osml10n_get_country(feature geometry) RETURNS TEXT AS
    order by area limit 1;
    return country;
  END;
-$$ LANGUAGE 'plpgsql' STABLE STRICT;
+$$ LANGUAGE 'plpgsql' STABLE STRICT PARALLEL SAFE;

--- a/plpgsql/get_country.sql
+++ b/plpgsql/get_country.sql
@@ -14,11 +14,11 @@ http://www.nominatim.org/data/country_grid.sql.gz
 example call:
 
 yourdb=# select osml10n_get_country(ST_GeomFromText('POINT(9 49)', 4326));
- get_country 
+ get_country
  -------------
   de
   (1 row)
-  
+
 */
 
 CREATE or REPLACE FUNCTION osml10n_get_country(feature geometry) RETURNS TEXT AS $$
@@ -31,4 +31,4 @@ CREATE or REPLACE FUNCTION osml10n_get_country(feature geometry) RETURNS TEXT AS
    order by area limit 1;
    return country;
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE STRICT;

--- a/plpgsql/get_country_name.sql
+++ b/plpgsql/get_country_name.sql
@@ -77,4 +77,4 @@ CREATE or REPLACE FUNCTION osml10n_get_country_name(tags hstore, separator text 
   END IF;
   return array_to_string(names,separator);
  END;
-$$ LANGUAGE 'plpgsql' STABLE;
+$$ LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;

--- a/plpgsql/street_abbrv.sql
+++ b/plpgsql/street_abbrv.sql
@@ -66,7 +66,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev(longname text, langcode text) R
   WHEN undefined_function THEN
    return longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;
 
 /*
    helper function "osml10n_street_abbrev_all"

--- a/plpgsql/street_abbrv.sql
+++ b/plpgsql/street_abbrv.sql
@@ -13,43 +13,38 @@ Street abbreviation functions
 
 */
 
-/* 
+/*
    helper function "osml10n_street_abbrev_all_latin"
    call all latin osml10n_street_abbrev functions
    These are currently: English, German and French
-   
+
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_latin(longname text) RETURNS TEXT AS $$
- DECLARE
-  abbrev text;
- BEGIN
-  abbrev=osml10n_street_abbrev_en(longname);
-  abbrev=osml10n_street_abbrev_de(abbrev);
-  abbrev=osml10n_street_abbrev_fr(abbrev);
-  return abbrev;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+ SELECT
+   osml10n_street_abbrev_fr(
+     osml10n_street_abbrev_de(
+       osml10n_street_abbrev_en(
+         longname)));
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+
+/*
    helper function "osml10n_street_abbrev_non_latin"
    call all non latin osml10n_street_abbrev functions
    These are currently: Russian, Ukrainian
-   
+
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_non_latin(longname text) RETURNS TEXT AS $$
- DECLARE
-  abbrev text;
- BEGIN
-  abbrev=osml10n_street_abbrev_ru(longname);
-  abbrev=osml10n_street_abbrev_uk(abbrev);
-  return abbrev;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+ SELECT
+   osml10n_street_abbrev_uk(
+     osml10n_street_abbrev_ru(
+       longname));
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev"
    will call the osml10n_street_abbrev function of the given language if available
-   and return the unmodified input otherwise   
+   and return the unmodified input otherwise
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev(longname text, langcode text) RETURNS TEXT AS $$
  DECLARE
@@ -62,7 +57,7 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev(longname text, langcode text) R
   END IF;
   IF (position('_' in langcode)>0) THEN
     return longname;
-  END IF;  
+  END IF;
   func ='osml10n_street_abbrev_'|| langcode;
   call = 'select ' || func || '(' || quote_nullable(longname) || ')';
   execute call into result;
@@ -71,13 +66,13 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev(longname text, langcode text) R
   WHEN undefined_function THEN
    return longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_all"
    call all osml10n_street_abbrev functions
    These are currently russian, english and german
-   
+
 */
 CREATE OR REPLACE FUNCTION osml10n_street_abbrev_all(longname text) RETURNS TEXT AS $$
  SELECT
@@ -86,9 +81,9 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_all(longname text) RETURNS TEXT
   ELSE
     osml10n_street_abbrev_latin(longname)
   END;
-$$ LANGUAGE SQL IMMUTABLE;
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_de"
    replaces some common parts of German street names with their abbr
 */
@@ -129,9 +124,9 @@ CREATE or REPLACE FUNCTION osml10n_street_abbrev_de(longname text) RETURNS TEXT 
   END IF;
   return abbrev;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_fr"
    replaces some common parts of French street names with their abbreviation
    Main source: https://www.canadapost.ca/tools/pg/manual/PGaddress-f.asp#1460716
@@ -168,31 +163,27 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_fr(longname text) RETURNS TEXT 
   
   RETURN longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_es"
    replaces some common parts of Spanish street names with their abbreviation
    currently just a stub :(
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_es(longname text) RETURNS TEXT AS $$
- BEGIN
-  return longname;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+ SELECT longname;
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_pt"
    replaces some common parts of Portuguese street names with their abbreviation
    currently just a stub :(
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_pt(longname text) RETURNS TEXT AS $$
- BEGIN
-  return longname;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+ SELECT longname;
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_en"
    replaces some common parts of English street names with their abbreviation
    Most common abbreviations extracted from:
@@ -244,46 +235,41 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_en(longname text) RETURNS TEXT 
 
   RETURN longname;
  END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
 
 
-/* 
+/*
    helper function "osml10n_street_abbrev_ru"
    replaces улица (ulica) with ул. (ul.)
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_ru(longname text) RETURNS TEXT AS $$
- DECLARE
-  abbrev text;
- BEGIN
-  abbrev=replace(longname,'переулок','пер.');
-  abbrev=replace(abbrev,'тупик','туп.');
-  abbrev=replace(abbrev,'улица','ул.');
-  abbrev=replace(abbrev,'бульвар','бул.');
-  abbrev=replace(abbrev,'площадь','пл.');
-  abbrev=replace(abbrev,'проспект','просп.');
-  abbrev=replace(abbrev,'спуск','сп.');
-  abbrev=replace(abbrev,'набережная','наб.');
-  return abbrev;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+ SELECT replace(replace(replace(replace(replace(replace(replace(replace(
+   longname,
+   'переулок', 'пер.'),
+   'тупик', 'туп.'),
+   'улица', 'ул.'),
+   'бульвар', 'бул.'),
+   'площадь', 'пл.'),
+   'проспект', 'просп.'),
+   'спуск', 'сп.'),
+   'набережная', 'наб.');
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 
-/* 
+/*
    helper function "osml10n_street_abbrev_uk"
    replaces ukrainian street suffixes with their abbreviations
 */
-CREATE or REPLACE FUNCTION osml10n_street_abbrev_uk(longname text) RETURNS TEXT AS $$
- DECLARE
-  abbrev text;
- BEGIN
-  abbrev=replace(longname,'провулок','пров.');
-  abbrev=replace(abbrev,'тупик','туп.');
-  abbrev=replace(abbrev,'вулиця','вул.');
-  abbrev=replace(abbrev,'бульвар','бул.');
-  abbrev=replace(abbrev,'площа','пл.');
-  abbrev=replace(abbrev,'проспект','просп.');
-  abbrev=replace(abbrev,'спуск','сп.');
-  abbrev=replace(abbrev,'набережна','наб.');
-  return abbrev;
- END;
-$$ LANGUAGE 'plpgsql' IMMUTABLE;
+CREATE or REPLACE FUNCTION osml10n_street_abbrev_uk(longname text) RETURNS TEXT AS
+$$
+ SELECT replace(replace(replace(replace(replace(replace(replace(
+   longname,
+   'провулок', 'пров.'),
+   'тупик', 'туп.'),
+   'вулиця', 'вул.'),
+   'бульвар', 'бул.'),
+   'площа', 'пл.'),
+   'проспект', 'просп.'),
+   'спуск', 'сп.'),
+   'набережна', 'наб.');
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;

--- a/plpgsql/street_abbrv.sql
+++ b/plpgsql/street_abbrv.sql
@@ -160,7 +160,7 @@ CREATE OR REPLACE FUNCTION osml10n_street_abbrev_fr(longname text) RETURNS TEXT 
       WHEN 'Sentier' THEN 'Sent.'
     END || substr(longname, length(match[1]) + 1);
   END IF;
-  
+
   RETURN longname;
  END;
 $$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE COST 20;
@@ -262,7 +262,7 @@ $$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE COST 20;
 */
 CREATE or REPLACE FUNCTION osml10n_street_abbrev_uk(longname text) RETURNS TEXT AS
 $$
- SELECT replace(replace(replace(replace(replace(replace(replace(
+ SELECT replace(replace(replace(replace(replace(replace(replace(replace(
    longname,
    'провулок', 'пров.'),
    'тупик', 'туп.'),


### PR DESCRIPTION
* Use SQL instead of 'plpgsql' when possible (allows for inlining)
* declare functions as strict when relevant
* mark abbreviation functions as parallel safe
* add execution cost lower than the default 100 for non-data-accessing functions.
* trimmed a few trailing spaces