### PR TITLE
Improve osml10n_get_country() perf by 20%

### DIFF
--- a/gen_osml10n_extension.sh
+++ b/gen_osml10n_extension.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # generate psql extension "osml10n"
 # from plpgsql scripts
@@ -43,17 +43,12 @@ echo "CREATE OR REPLACE FUNCTION osml10n_kanji_transcript(text)RETURNS text AS"
 echo "'\$libdir/osml10n_kanjitranscript', 'osml10n_kanji_transcript'"
 echo "LANGUAGE C STRICT;"
 echo
-echo "-- enable libkakasi based kanji transcription function -----------------------------------------------------------------" 
+echo "-- enable libkakasi based kanji transcription function -----------------------------------------------------------------"
 echo
 echo "CREATE OR REPLACE FUNCTION osml10n_translit(text)RETURNS text AS"
 echo "'\$libdir/osml10n_translit', 'osml10n_translit'"
 echo "LANGUAGE C STRICT;" ) >>osml10n--$2.sql
 
-for f in $SCRIPTS; do
-  echo "" >>osml10n--$2.sql
-  echo "-- pl/pgSQL code from file $f -----------------------------------------------------------------" >>osml10n--$2.sql
-  cat plpgsql/$f >>osml10n--$2.sql
-done
 echo "-- country_osm_grid.sql -----------------------------------------------------------------" >>osml10n--$2.sql
 sed -e '/^COPY.*$/,/^\\\.$/d;//d' -e 's/CREATE TABLE country_osm_grid/CREATE TABLE IF NOT EXISTS country_osm_grid/g' country_osm_grid.sql |grep -v -e '^--' |grep -v 'CREATE INDEX' | cat -s >>osml10n--$2.sql
 echo "DELETE from country_osm_grid;" >>osml10n--$2.sql
@@ -69,6 +64,12 @@ echo "COPY country_languages (iso, langs) FROM '$1/country_languages.data';"  >>
 # for now we need to force srid here because boundaries/hkmo2psql.py does not include srid in geometry output
 echo -e "UPDATE country_osm_grid SET geometry=ST_SetSRID(geometry,4326);\n" >>osml10n--$2.sql
 echo -e "GRANT SELECT on country_languages to public;\n" >>osml10n--$2.sql
+
+for f in $SCRIPTS; do
+  echo "" >>osml10n--$2.sql
+  echo "-- pl/pgSQL code from file $f -----------------------------------------------------------------" >>osml10n--$2.sql
+  cat plpgsql/$f >>osml10n--$2.sql
+done
 
 echo "
 -- function osml10n_version  -----------------------------------------------------------------

--- a/plpgsql/get_country.sql
+++ b/plpgsql/get_country.sql
@@ -14,21 +14,17 @@ http://www.nominatim.org/data/country_grid.sql.gz
 example call:
 
 yourdb=# select osml10n_get_country(ST_GeomFromText('POINT(9 49)', 4326));
- get_country 
+ get_country
  -------------
   de
   (1 row)
-  
+
 */
 
 CREATE or REPLACE FUNCTION osml10n_get_country(feature geometry) RETURNS TEXT AS $$
- DECLARE
-  country text;
- BEGIN
-   SELECT country_code into country
-   from country_osm_grid
-   where st_contains(geometry, st_centroid(st_transform(feature,4326)))
-   order by area limit 1;
-   return country;
- END;
-$$ LANGUAGE 'plpgsql' STABLE;
+ SELECT country_code
+ from country_osm_grid
+ where st_contains(geometry, st_centroid(st_transform(feature,4326)))
+ order by area
+ limit 1;
+$$ LANGUAGE SQL STABLE;


### PR DESCRIPTION
Use SQL instead of PLPGSQL to gain 20% of performance. Measured with `profile-pg-func` tool.  To test locally. Must have `docker`, `make`, and `git`.

* git clone https://github.com/openmaptiles/openmaptiles
* edit `.env` file to use tools version 5.1 instead of 5.0 (it hasn't been upgraded just yet)
* place this file in the openmaptiles/ dir as `get-country.sql`
* run `make start-db` to create a new docker database
* run `make bash`     to start tools
* run test with this command
```
profile-pg-func --file get-country.sql 'osml10n_get_country_o({random_geopoint})' 'osml10n_get_country_n({random_geopoint})' --calls 10000
```
* exit container and cleanup with `make destroy-db`

```sql
-- File get-country.sql
CREATE or REPLACE FUNCTION osml10n_get_country_o(feature geometry) RETURNS TEXT AS $$
 DECLARE
  country text;
 BEGIN
   SELECT country_code into country
   from country_osm_grid
   where st_contains(geometry, st_centroid(st_transform(feature,4326)))
   order by area limit 1;
   return country;
 END;
$$ LANGUAGE 'plpgsql' STABLE;

CREATE or REPLACE FUNCTION osml10n_get_country_n(feature geometry) RETURNS TEXT AS $$
 SELECT country_code
 from country_osm_grid
 where st_contains(geometry, st_centroid(st_transform(feature,4326)))
 order by area
 limit 1;
$$ LANGUAGE SQL STABLE;
```

### Results
```
Importing get_country.sql...
Running 2 functions x 10 runs x 10,000 each...
...
% slower    Function                                     AVG of 8 runs    MIN             MAX                  STDEV
----------  -------------------------------------------  ---------------  --------------  --------------  ----------
            2) osml10n_get_country_n({random_geopoint})  0:00:01.751501   0:00:01.741989  0:00:01.759559  0.00634216
21.0%       1) osml10n_get_country_o({random_geopoint})  0:00:02.118865   0:00:02.101815  0:00:02.138070  0.0137719
```