### PR TITLE
Fix country grid download

### DIFF
--- a/gen_osml10n_extension.sh
+++ b/gen_osml10n_extension.sh
@@ -20,7 +20,7 @@ done
 if ! [ -f "country_osm_grid.sql" ]; then
   rm -f country_osm_grid.sql
   echo -n "Trying to download country_grid.sql.gz from nominatim.org... "
-  curl -s http://www.nominatim.org/data/country_grid.sql.gz |gzip -d >country_osm_grid.sql
+  curl -s https://nominatim.org/data/country_grid.sql.gz |gzip -d >country_osm_grid.sql
 
   if ! [ -s country_osm_grid.sql ]; then
     rm -f country_osm_grid.sql


### PR DESCRIPTION
The download currently fails as curl doesn't follow the redirect:

```
curl -vvv http://www.nominatim.org/data/country_grid.sql.gz
*   Trying 138.201.190.130:80...
* Connected to www.nominatim.org (138.201.190.130) port 80 (#0)
> GET /data/country_grid.sql.gz HTTP/1.1
> Host: www.nominatim.org
> User-Agent: curl/7.74.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.18.0
< Date: Wed, 01 Dec 2021 13:55:05 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://www.nominatim.org/data/country_grid.sql.gz
```